### PR TITLE
Update map-google.init.js

### DIFF
--- a/admin/seller/includes/dist/js/pages/maps/map-google.init.js
+++ b/admin/seller/includes/dist/js/pages/maps/map-google.init.js
@@ -193,7 +193,7 @@ $(function() {
     });
     map_7.addMapType("osm", {
         getTileUrl: function(coord, zoom) {
-            return "https://a.tile.openstreetmap.org/" + zoom + "/" + coord.x + "/" + coord.y + ".png";
+            return "https://tile.openstreetmap.org/" + zoom + "/" + coord.x + "/" + coord.y + ".png";
         },
         tileSize: new google.maps.Size(256, 256),
         name: "OpenStreetMap",


### PR DESCRIPTION
`a.` is no longer recommended now that we support HTTP/2 + HTTP/3.